### PR TITLE
removed hal as a hard dependancy

### DIFF
--- a/Gentoo/media-tv/mythtv/mythtv-0.25_pre20110429.ebuild
+++ b/Gentoo/media-tv/mythtv/mythtv-0.25_pre20110429.ebuild
@@ -26,6 +26,7 @@ perl python \
 vdpau \
 xvid x264 \
 experimental \
+hal \
 ${IUSE_VIDEO_CARDS} \
 input_devices_joystick \
 "
@@ -75,7 +76,7 @@ RDEPEND="
     !media-tv/mythtv-bindings
 	dev-python/dbus-python
 	dev-python/simplejson
-	sys-apps/hal
+    hal?  ( sys-apps/hal )
     x264? ( >=media-libs/x264-0.0.20100605 )
     xvid? ( >=media-libs/xvid-1.1.0 )
 	"


### PR DESCRIPTION
hal does not seem critical to mythtv running and conflicts with upower/udisks that are pulled in by the kde libs myth pulls in on my system - note that i have not tested this ebuild and it will need "digested"( i just removed the hal dep locally and nothing bad happened :) )
