### PR TITLE
Don't reupload the orig.tar.gz in all uploads to ubuntu PPAs

### DIFF
--- a/deb/build-debs.sh
+++ b/deb/build-debs.sh
@@ -150,7 +150,7 @@ if [ "$TYPE" = "binary" ]; then
     get-build-deps || die "Error installing build dependencies"
 
 elif [ "$TYPE" = "source" ]; then
-    DEBUILD_FLAGS="-S -sa $DEBUILD_FLAGS"
+    DEBUILD_FLAGS="-S $DEBUILD_FLAGS"
 fi
 
 #update changelog and control files


### PR DESCRIPTION
Should hopefully fix the problem of going over the 3GB per PPA limit until the next publisher run.
