### PR TITLE
Add support to build with a patch directly for deb/dsc builds

### DIFF
--- a/deb/build-debs.sh
+++ b/deb/build-debs.sh
@@ -30,6 +30,7 @@ help()
 	exit 0
 }
 
+export QUILT_PATCHES="debian/patches"
 [ -n "$GIT_BRANCH" ] && GIT_BRANCH=""
 [ -n "$DIRECTORY" ] && DIRECTORY=""
 [ -n "$PATCHES" ] && PATCHES=""


### PR DESCRIPTION
This change allows additional arguments to the deb/dsc build scripts to allow integration of a patch.  The primary use case for it is someone who is requested to test a patch to solve a trac ticket but is using mythbuntu builds.

The workflow will be:
1) git clone packaging branch
2) packaging/deb/build-debs.sh fixes/0.24 $DIRECTORY_TO_BUILD_IN /full/path/to/patch/to/use
2) Install debs to test

If they don't want to build locally they can alternatively build the source package locally and push to a PPA:
1) git clone packaging branch
2) packaging/deb/build-dsc.sh fixes/0.24 $DIRECTORY_TO_BUILD_IN /full/path/to/patch/to/use
3) dput ppa:blah $DIRECTORY_TO_BUILD_IN/*.changes
4) apt-add-repository ppa:blah
5) apt-get update
6) apt-get dist-upgrade
