### PR TITLE
Use git pull --rebase for Gentoo selfupdate script

### DIFF
--- a/Gentoo/scripts/selfupdate
+++ b/Gentoo/scripts/selfupdate
@@ -7,5 +7,5 @@ cd $selfpath/../
 reponame=`cat profiles/repo_name`
 
 echo "Updating $reponame..."
-git pull
+git pull --rebase
 


### PR DESCRIPTION
Somehow my repo got into a state where `git pull` attempted a merge commit. Strange, because I hadn't touched the repo, just let it self update. This prevented any further self updates (because the repo was stuck in the middle of a merge) and broke the overlay until I manually did `git reset --hard`. Using `git pull --rebase` should mitigate the chance of this happening again. As an added bonus, any local commits get preserved and rebased onto the tip of the remote branch. It is still possible for `git pull --rebase` to get into a state that would require manual intervention (especially with any local commits), but far less likely.

An alternative I considered, but ultimately decided against would be to do `git fetch origin` followed by `git rebase --hard origin/master`. This method will destroy any local commits on the current local branch and it requires the script to know in advance which remote is the upstream repository. Assuming 'origin' would probably work a majority of the time, but is a little too fragile for a self update imo.
