### PR TITLE
In Ubuntu Precise the script 'get-build-deps' is no longer present

### DIFF
--- a/deb/build-debs.sh
+++ b/deb/build-debs.sh
@@ -34,7 +34,7 @@ export QUILT_PATCHES="debian/patches"
 [ -n "$GIT_BRANCH" ] && GIT_BRANCH=""
 [ -n "$DIRECTORY" ] && DIRECTORY=""
 [ -n "$PATCHES" ] && PATCHES=""
-[ -z "$DEBUILD_FLAGS" ] && DEBUILD_FLAGS="-d -us -uc -i -I.git"
+[ -z "$DEBUILD_FLAGS" ] && DEBUILD_FLAGS="-us -uc -i -I.git"
 
 if [ -z "$1" ]; then
 	help
@@ -155,24 +155,6 @@ if [ ! -f ../mythtv_$UPSTREAM_VERSION.orig.tar.gz ]; then
 fi
 
 if [ "$TYPE" = "binary" ]; then
-    #Make sure we have the package for get-build-deps
-    if ! which get-build-deps 2>&1 1>/dev/null; then
-        echo "Missing ubuntu-dev-tools, marking for installation"
-        sudo apt-get install ubuntu-dev-tools --no-install-recommends || die "Error installing ubuntu-dev-tools"
-    fi
-
-    #pbuilder is used by get-build deps
-    if ! which pbuilder 2>&1 1>/dev/null; then
-        echo "Missing pbuilder, marking for installation"
-        sudo apt-get install pbuilder || die "Error installing pbuilder"
-    fi
-
-    #aptitude is used by get-build deps
-    if ! which aptitude 2>&1 1>/dev/null; then
-        echo "Missing aptitude, marking for installation"
-        sudo apt-get install aptitude || die "Error installing aptitude"
-    fi
-
     #grab build dependencies
     sudo apt-get build-dep mythtv || die "Error installing build dependencies"
 


### PR DESCRIPTION
Replace the call to the script with a direct 'apt-get build-dep' to get things working again.
