### PR TITLE
Fix installing mythweb to html dir on older releases (LP #1309813)

### DIFF
--- a/deb/debian/changelog.in
+++ b/deb/debian/changelog.in
@@ -98,6 +98,7 @@ mythtv (2:0.27.0~master.20130828.b2b7022-0ubuntu1) saucy; urgency=low
 
   [ Thomas Mashos ]
   * Fix wanting to install mythweb to html dir on older releases (LP: #1309813)
+  * Enable CGI module on apache2 for mythweb (LP: #1316409)
 
  -- Mario Limonciello <superm1@ubuntu.com>  Wed, 28 Aug 2013 22:06:14 -0500
 

--- a/deb/debian/mythweb.postinst
+++ b/deb/debian/mythweb.postinst
@@ -182,8 +182,9 @@ s/\(^[ \t]*setenv[ \t]\+db_password[ \t]\+\"\)[^\"]*\"/\1$mythtv_password\"/g;
                 disableauth "${MYTHWEBCONF}" || true
             fi
 
-            # Enable rewrite_module and reload apache.
+            # Enable rewrite_module and cgi and reload apache.
             a2enmod rewrite >/dev/null || true
+            a2enmod cgi >/dev/null || true
             a2ensite mythweb.conf >/dev/null || true
 
             # Usability feature to make / redirect to /mythweb in apache


### PR DESCRIPTION
I believe this will fix installing mythweb to the right directory
