### PR TITLE
Remaining fixes for source-package Debian compatibility.

### DIFF
--- a/deb/debian/mythtv-backend.init
+++ b/deb/debian/mythtv-backend.init
@@ -1,0 +1,87 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          mythtv-backend
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Should-Start:      mysql
+# Should-Stop:       mysql
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# X-Interactive:     true
+# Short-Description: Start/Stop the MythTV server.
+### END INIT INFO
+
+if [ -f /etc/default/locale ]; then
+  . /etc/default/locale
+  export LANG
+fi
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/bin/mythbackend
+NAME="mythbackend"
+DESC="MythTV server"
+
+test -x $DAEMON || exit 0
+
+. /lib/lsb/init-functions
+
+set -e
+
+USER=mythtv
+RUNDIR=/var/run/mythtv
+ARGS="--daemon --syslog local7 --pidfile $RUNDIR/$NAME.pid"
+EXTRA_ARGS=""
+NICE=0
+
+if [ -f /etc/default/mythtv-backend ]; then
+  . /etc/default/mythtv-backend
+fi
+
+ARGS="$ARGS $EXTRA_ARGS"
+
+mkdir -p $RUNDIR
+chown -R $USER $RUNDIR
+
+unset DISPLAY
+unset SESSION_MANAGER
+
+case "$1" in
+  start)
+	if test -e $RUNDIR/$NAME.pid ; then
+		echo "mythbackend already running, use restart instead."
+	else
+		echo -n "Starting $DESC: $NAME "
+		start-stop-daemon --start --pidfile $RUNDIR/$NAME.pid \
+			--chuid $USER --nicelevel $NICE --exec $DAEMON -- $ARGS
+		echo "."
+	fi
+	;;
+  stop)
+	echo -n "Stopping $DESC: $NAME "
+	start-stop-daemon --stop --oknodo --pidfile $RUNDIR/$NAME.pid \
+		--chuid $USER --exec $DAEMON -- $ARGS
+	test -e $RUNDIR/$NAME.pid && rm $RUNDIR/$NAME.pid
+	echo "."
+	;;
+  restart|force-reload)
+	echo -n "Restarting $DESC: $NAME "
+	start-stop-daemon --stop --oknodo --retry 10 --pidfile $RUNDIR/$NAME.pid \
+                --chuid $USER --exec $DAEMON -- $ARGS
+	echo "."
+	start-stop-daemon --start --pidfile $RUNDIR/$NAME.pid \
+                --chuid $USER --nicelevel $NICE --exec $DAEMON -- $ARGS
+	echo "."
+	;;
+  reload)
+  	start-stop-daemon --stop --oknodo --signal HUP --pidfile \
+  	$RUNDIR/$NAME.pid --chuid $USER --exec $DAEMON -- $ARGS
+  	echo "."
+  	;;
+  *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|restart|force-reload}" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/deb/debian/mythtv-common.postinst
+++ b/deb/debian/mythtv-common.postinst
@@ -75,7 +75,12 @@ case "$1" in
 
     #fix rsyslog permissions
     if [ -d "/var/log/mythtv" ] && ! dpkg-statoverride --list "/var/log/mythtv" >/dev/null; then
-        chown syslog:adm -R /var/log/mythtv
+        #syslog user not normally present on debian
+        if getent passwd syslog 1>/dev/null; then
+            chown syslog:adm -R /var/log/mythtv
+        else
+            chown root:adm -R /var/log/mythtv
+        fi
         chmod 2755 /var/log/mythtv
     fi
 


### PR DESCRIPTION
+ Fix postinst to not require ubuntu-specific 'syslog' user.
+ Include sysvinit script suitable for wheezy and jessie (latter
    case still needed especially on upgraded systems that may not
    have switched to systemd init).