### PR TITLE
Fix mysql.d config entry, allow IPv6 connections to backend mysql ser…

### DIFF
--- a/deb/debian/mythtv.cnf
+++ b/deb/debian/mythtv.cnf
@@ -1,3 +1,3 @@
 [mysqld]
-#bind-address=0.0.0.0
+#bind-address=::
 max_connections=100


### PR DESCRIPTION
Note the mythbackend process already supports IPv6 connections.
Previously tested this change and this corrected IPv6-connections to backend successfully.

Potential (but not yet proved) concern this fix may cause 'replace manually maintained config file' prompts with some users (those who have selected mythtv listen on network hence script removed the # separately).  This is to be tested on the upgrade-package case.

Hoping this fix can at least go into 'master' in the first instance, as a safe bet.
