### PR TITLE
Correct version for fixes/0.27 builds

### DIFF
--- a/deb/debian/changelog.in
+++ b/deb/debian/changelog.in
@@ -1,11 +1,11 @@
-mythtv (2:0.27.5~dummy_changelog_entry-manualbuild) jessie; urgency=low
+mythtv (2:0.27.5~dummychangelogentry-manualbuild) jessie; urgency=low
 
   * Dummy changelog entry to bump version to 0.27.5 as
     this changelog.in in packaging is not automatically updated
     at present.  This entry allows build-{dsc/debs}.sh to pick
     up "0.27.5" version at present.
 
- -- Simon Iremonger <debian@iremonger.me.uk>  Fri, 21 Aug 2015 15:35:00 +0100
+ -- Simon Iremonger <debian@iremonger.me.uk>  Fri, 21 Aug 2015 15:39:00 +0100
 
 mythtv (2:0.27.0~master.20130828.b2b7022-0ubuntu1) saucy; urgency=low
 

--- a/deb/debian/changelog.in
+++ b/deb/debian/changelog.in
@@ -1,3 +1,12 @@
+mythtv (2:0.27.5~dummy-changelog-entry) saucy; urgency=low
+
+  * Dummy changelog entry to bump version to 0.27.5 as
+    this changelog.in in packaging is not automatically updated
+    at present.  This entry allows build-{dsc/debs}.sh to pick
+    up "0.27.5" version at present.
+
+ -- Simon Iremonger <debian@iremonger.me.uk>  Fri, 21 Aug 2015 15:14:26 +0100
+
 mythtv (2:0.27.0~master.20130828.b2b7022-0ubuntu1) saucy; urgency=low
 
   * New upstream checkout (b2b7022)

--- a/deb/debian/changelog.in
+++ b/deb/debian/changelog.in
@@ -1,11 +1,11 @@
-mythtv (2:0.27.5~dummy-changelog-entry) saucy; urgency=low
+mythtv (2:0.27.5~dummy_changelog_entry-manualbuild) jessie; urgency=low
 
   * Dummy changelog entry to bump version to 0.27.5 as
     this changelog.in in packaging is not automatically updated
     at present.  This entry allows build-{dsc/debs}.sh to pick
     up "0.27.5" version at present.
 
- -- Simon Iremonger <debian@iremonger.me.uk>  Fri, 21 Aug 2015 15:14:26 +0100
+ -- Simon Iremonger <debian@iremonger.me.uk>  Fri, 21 Aug 2015 15:35:00 +0100
 
 mythtv (2:0.27.0~master.20130828.b2b7022-0ubuntu1) saucy; urgency=low
 


### PR DESCRIPTION
Would like this commited to fixes/0.27 at least. 
Causes version to come out correctly as e.g. 0.27.5+fixes.20150821.e2a11c9-manualbuild
Maybe this should (for now) go into master as well?
