### PR TITLE
Fixes to preinst/postinst to handle updating to ipv6-compatible mysql-socket without prompting user.

### DIFF
--- a/deb/debian/mythtv-database.postinst
+++ b/deb/debian/mythtv-database.postinst
@@ -1,6 +1,7 @@
 #!/bin/sh -e
 MYSQL="/usr/share/mythtv/sql/mythtv*.sql"
 MYSQLCONFIG="/etc/mysql/conf.d/mythtv.cnf"
+MYSQLCONFIGUPDATEHINT="/etc/mysql/conf.d/mythtv.cnf.ipv6update-with-public_bind.tmp"
 FSTAB="/etc/fstab"
 NEWIP="127.0.0.1"
 LOCALHOSTNAME=`cat /etc/hostname`
@@ -48,6 +49,15 @@ update_database() {
 
 case "$1" in
     configure)
+
+    #Fixup mysql binding ipv6-compatibility config-update when public_bind was in use (hint from preinst)
+    if [ -f "${MYSQLCONFIG}" ]; then
+        if [ -f "${MYSQLCONFIGUPDATEHINT}" ]; then
+            sed -i -e 's/^#bind-address=::$/bind-address=::/' ${MYSQLCONFIG}
+            rm ${MYSQLCONFIGUPDATEHINT}
+        fi
+    fi
+
     . /usr/share/debconf/confmodule
 
     db_get mythtv/mysql_mythtv_dbname

--- a/deb/debian/mythtv-database.preinst
+++ b/deb/debian/mythtv-database.preinst
@@ -3,19 +3,20 @@ MYSQLCONFIG="/etc/mysql/conf.d/mythtv.cnf"
 MYSQLCONFIGUPDATEHINT="/etc/mysql/conf.d/mythtv.cnf.ipv6update-with-public_bind.tmp"
 
 #This script (in combination with postinst amendment) purely to handle update-cases
-#  from old installations with public_bind enabled so they seamlessly update without
-#  generating needless "configuration modified by user" prompts.
+#  from old installations with public_bind enabled so they seamlessly update to ipv6-
+#  compatible mysql-socket without needless "configuration modified by user" prompts.
 
 case "$1" in
     upgrade)
     if [ -f "${MYSQLCONFIG}" ]; then
         if grep ^bind-address=0.0.0.0$ ${MYSQLCONFIG} > /dev/null; then
-          sed -i -e 's/^bind-address=0.0.0.0$/#bind-address=0.0.0.0/' ${MYSQLCONFIG}
           echo "#" > ${MYSQLCONFIGUPDATEHINT}
+          sed -i -e 's/^bind-address=0.0.0.0$/#bind-address=0.0.0.0/' ${MYSQLCONFIG}
         fi
-        #in the case that public-binding was enabled, restore the original default-config, leaving
-        #  a hint to the postinst which fixes this up upon postinst configure.
-        #only users who actually modified /etc/mysql/conf.d/mythtv.cnf manually will get prompted.
+        #In the case that public-binding was enabled, restore the original default-config,
+        #  allowing dpkg todo the config-file-update without prompt, then the postinst
+        #  will fix this up upon postinst configure.
+        #Only users who actually modified /etc/mysql/conf.d/mythtv.cnf manually will get prompted.
     fi
 esac
 

--- a/deb/debian/mythtv-database.preinst
+++ b/deb/debian/mythtv-database.preinst
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+MYSQLCONFIG="/etc/mysql/conf.d/mythtv.cnf"
+MYSQLCONFIGUPDATEHINT="/etc/mysql/conf.d/mythtv.cnf.ipv6update-with-public_bind.tmp"
+
+#This script (in combination with postinst amendment) purely to handle update-cases
+#  from old installations with public_bind enabled so they seamlessly update without
+#  generating needless "configuration modified by user" prompts.
+
+case "$1" in
+    upgrade)
+    if [ -f "${MYSQLCONFIG}" ]; then
+        if grep ^bind-address=0.0.0.0$ ${MYSQLCONFIG} > /dev/null; then
+          sed -i -e 's/^bind-address=0.0.0.0$/#bind-address=0.0.0.0/' ${MYSQLCONFIG}
+          echo "#" > ${MYSQLCONFIGUPDATEHINT}
+        fi
+        #in the case that public-binding was enabled, restore the original default-config, leaving
+        #  a hint to the postinst which fixes this up upon postinst configure.
+        #only users who actually modified /etc/mysql/conf.d/mythtv.cnf manually will get prompted.
+    fi
+esac
+
+exit 0


### PR DESCRIPTION
Agreed with superm1 this should go into Master for now.
Later, after 0.28 users' update-testing, this *along with separate commit #62 should hopefully be backported to fixes/0.27 .