### PR TITLE
https://code.mythtv.org/trac/ticket/12964

### DIFF
--- a/deb/debian/mythtv-database.cron.weekly
+++ b/deb/debian/mythtv-database.cron.weekly
@@ -10,7 +10,17 @@ DEBIAN="--defaults-extra-file=/etc/mysql/debian.cnf"
 
 /usr/bin/mysqlcheck $DEBIAN -s $DBNAME
 
-/usr/share/mythtv/mythconverg_backup.pl
+if [ -e "/etc/default/mythtv-backend" ]; then
+   . /etc/default/mythtv-backend
+fi
+
+if [ "$USER" = "" ]; then
+   CMDPREFIX=""
+else
+   CMDPREFIX="sudo -u $USER"
+fi
+
+$CMDPREFIX /usr/share/mythtv/mythconverg_backup.pl
 
 /usr/bin/logger -p daemon.info -i -t${0##*/} "$DBNAME checked and backed up."
 


### PR DESCRIPTION
 The mythtv backup scripts exists with error code 2 and does no backup if root has an .my.cnf file for mysqldump with different user.

The reason is already described in then code of "mythconverg_backup.pl":

        verbose($verbose_level_debug,
                '', "Attempting to use supplied password for $mysqldump.",
                'Any [client] or [mysqldump] password specified in the MySQL'.
                ' options file will',
                'take precedence.');

By reading the /etc/default/mythtv-backend file and using sudo if the mythv user is set,this could be solved.