### PR TITLE
mythtv-backend does not stop when running mythtv-setup.

### DIFF
--- a/deb/debian/mythtv-setup.sh
+++ b/deb/debian/mythtv-setup.sh
@@ -39,7 +39,7 @@ check_groups
 
 #if group membership is okay, go ahead and continue
 if [ "$IGNORE_NOT" = "0" ]; then
-	RUNNING=$(status mythtv-backend | grep running)
+	RUNNING=$(ps -A | grep mythbackend)
 	if [ -n "$RUNNING" ]; then
 		dialog_question "MythTV Setup Preparation" "Mythbackend must be closed before continuing.\nIs it OK to close any currently running mythbackend processes?"
 		CLOSE_NOT=$?


### PR DESCRIPTION
This is due to RUNNING=$(status mythtv-backend | grep running) failing.
Replace with RUNNING=$(ps -A | grep mythbackend) which works on all systems.
Tested on Ubuntu 16.04 LTS and Debian Stretch

Edit 20180418
see https://code.mythtv.org/trac/ticket/13160
Also applies to Ubuntu 18.04