### PR TITLE
Debian/Ubuntu: Install Droid fonts instead of symlinking.

### DIFF
--- a/deb/debian/mythtv-common.install
+++ b/deb/debian/mythtv-common.install
@@ -8,6 +8,7 @@ usr/bin/mythutil
 usr/share/mythtv/*.xml
 usr/share/mythtv/*.pl
 usr/share/mythtv/locales
+usr/share/mythtv/fonts/Droid*.ttf
 usr/share/mythtv/fonts/Tiresias*.ttf
 usr/share/mythtv/internetcontent
 usr/share/mythtv/metadata

--- a/deb/debian/mythtv-common.links
+++ b/deb/debian/mythtv-common.links
@@ -1,10 +1,3 @@
-usr/share/fonts/truetype/droid/DroidSans.ttf usr/share/mythtv/fonts/DroidSans.ttf
-usr/share/fonts/truetype/droid/DroidSerif-Bold.ttf usr/share/mythtv/fonts/DroidSerif-Bold.ttf
-usr/share/fonts/truetype/droid/DroidSerif-Regular.ttf usr/share/mythtv/fonts/DroidSerif-Regular.ttf
-usr/share/fonts/truetype/droid/DroidSans-Bold.ttf usr/share/mythtv/fonts/DroidSans-Bold.ttf
-usr/share/fonts/truetype/droid/DroidSansMono.ttf usr/share/mythtv/fonts/DroidSansMono.ttf
-usr/share/fonts/truetype/droid/DroidSerif-Italic.ttf usr/share/mythtv/fonts/DroidSerif-Italic.ttf
-usr/share/fonts/truetype/droid/DroidSerif-BoldItalic.ttf usr/share/mythtv/fonts/DroidSerif-BoldItalic.ttf
 usr/share/fonts/truetype/freefont/FreeSans.ttf usr/share/mythtv/fonts/FreeSans.ttf
 usr/share/fonts/truetype/freefont/FreeMono.ttf usr/share/mythtv/fonts/FreeMono.ttf
 usr/share/fonts/truetype/freefont/FreeSansBold.ttf usr/share/mythtv/fonts/FreeSansBold.ttf

--- a/deb/debian/rules
+++ b/deb/debian/rules
@@ -136,7 +136,6 @@ override_dh_install:
 	cp debian/20-mythweb.ini   ${buildroot}/etc/php/7.0/apache2/conf.d; \
 	dh_install -Xusr/share/mythtv/fonts/Free \
                    -Xusr/share/mythtv/fonts/Purisa \
-                   -Xusr/share/mythtv/fonts/Droid \
                    -Xusr/share/mythtv/fonts/texgyrechorus \
                    -Xusr/lib/libmythzmq.la \
                    -Xusr/share/mythtv/fonts/tiresias_gpl3.txt \


### PR DESCRIPTION
The packaging/deb scripts create symlinks to Droid fonts that are no
longer available on Debian or Ubuntu. However, mythtv already has the
Droid fonts and installs them when mythtv is built from source.
This commit changes the debian/ubuntu packaging to install mythtv's
droid fonts instead of relying on fonts that were deprecated two years
ago and replaced by dejavu fonts that don't look right.

Cherry picked from fixes/29 commit: https://github.com/MythTV/packaging/commit/7dbe02656ff92e4a5d300f7b9f04afbf13a96a09

See also:
https://code.mythtv.org/trac/ticket/13301