### PR TITLE
debian: wait for the network to be online

### DIFF
--- a/deb/debian/mythtv-backend.service
+++ b/deb/debian/mythtv-backend.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=MythTV Backend
 Documentation=https://www.mythtv.org/wiki/Mythbackend
-After=mysql.service network.target
- 
+After=mysql.service network-online.target
+
 [Service]
 User=mythtv
 EnvironmentFile=-/etc/mythtv/additional.args
@@ -11,6 +11,6 @@ StartLimitBurst=10
 StartLimitInterval=10m
 Restart=on-failure
 RestartSec=1
- 
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When my MythTV backend boots up, it often fails to initialize my HDHomeRun tuners. it seems that other HDHomeRun users are also experiencing this problem: https://forum.mythtv.org/viewtopic.php?t=3212

I'm using the [MythTV 30](https://launchpad.net/~mythbuntu/+archive/ubuntu/30) PPA on Ubuntu 16.04.

`/var/log/mythtv/mythbackend.log` shows "Unable to find a free device" errors:
```
Apr 12 15:59:18 argilo-desktop mythbackend: mythbackend[1379]: I CoreContext recorders/hdhrstreamhandler.cpp:385 (Connect) HDHRSH[0](1040F35D): Added 0 devices from 1040F35D
Apr 12 15:59:18 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/hdhrstreamhandler.cpp:393 (Connect) HDHRSH[0](1040F35D): Unable to find a free device
Apr 12 15:59:18 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/channelbase.cpp:796 (CreateChannel) ChannelBase: CreateChannel() Error: Failed to open device 1040F35D
Apr 12 15:59:18 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext main_helpers.cpp:205 (setupTVs) Problem with capture cards. Card 3 failed init
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: I CoreContext recorders/hdhrstreamhandler.cpp:385 (Connect) HDHRSH[0](1040F35D): Added 0 devices from 1040F35D
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/hdhrstreamhandler.cpp:393 (Connect) HDHRSH[0](1040F35D): Unable to find a free device
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/channelbase.cpp:796 (CreateChannel) ChannelBase: CreateChannel() Error: Failed to open device 1040F35D
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext main_helpers.cpp:205 (setupTVs) Problem with capture cards. Card 4 failed init
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: I CoreContext recorders/hdhrstreamhandler.cpp:385 (Connect) HDHRSH[0](1040B672): Added 0 devices from 1040B672
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/hdhrstreamhandler.cpp:393 (Connect) HDHRSH[0](1040B672): Unable to find a free device
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/channelbase.cpp:796 (CreateChannel) ChannelBase: CreateChannel() Error: Failed to open device 1040B672
Apr 12 15:59:19 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext main_helpers.cpp:205 (setupTVs) Problem with capture cards. Card 5 failed init
Apr 12 15:59:20 argilo-desktop mythbackend: mythbackend[1379]: I CoreContext recorders/hdhrstreamhandler.cpp:385 (Connect) HDHRSH[0](1040B672): Added 0 devices from 1040B672
Apr 12 15:59:20 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/hdhrstreamhandler.cpp:393 (Connect) HDHRSH[0](1040B672): Unable to find a free device
Apr 12 15:59:20 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext recorders/channelbase.cpp:796 (CreateChannel) ChannelBase: CreateChannel() Error: Failed to open device 1040B672
Apr 12 15:59:20 argilo-desktop mythbackend: mythbackend[1379]: E CoreContext main_helpers.cpp:205 (setupTVs) Problem with capture cards. Card 6 failed init
```
I suspect the problem is that the MythTV backend starts up before the network is online, which prevents it from connecting to the HDHomeRun receivers. Changing `After=mysql.service network.target` to `After=mysql.service network-online.target` in `/lib/systemd/system/mythtv-backend.service` solved the problem for me; I rebooted my machine about 20 times, and my HDHomeRun tuners were always detected. Thus I'm proposing to make this change to MythTV's Debian packaging.

I noticed that `network-online.target` was changed to `network.target` by @tgm4883 in d0fe457164fc357ce250b5f5197a6ed256f2781b, which seems to have introduced this problem. I'm not sure whether that change was meant to correct some other problem since the commit message doesn't have any details.