### PR TITLE
Fix path to build-tools in setenv.sh

### DIFF
--- a/android/android-utilities/setenv.sh
+++ b/android/android-utilities/setenv.sh
@@ -7,7 +7,7 @@ export ANDROID_NDK=$ANDROID_ROOT/android-ndk
 export ANDROID_SDK_ROOT=$ANDROID_SDK
 export ANDROID_NDK_ROOT=$ANDROID_NDK
 if [ $(ls -1 "$ANDROID_SDK_ROOT/build-tools" | wc -l) == 1 ] ; then
-	export ANDROID_BUILD_TOOLS_REVISION=$(ls -1 $ANDROID_SDK_ROOT/android-sdk-linux/build-tools | grep "^[0-9]" | tail -1)
+	export ANDROID_BUILD_TOOLS_REVISION=$(ls -1 $ANDROID_SDK_ROOT/build-tools | grep "^[0-9]" | tail -1)
 	echo "Using discovered tools version $ANDROID_BUILD_TOOLS_REVISION"
 else
 	export ANDROID_BUILD_TOOLS_REVISION=29.0.2


### PR DESCRIPTION
android-sdk-linux is already part of $ANDROID_SDK_ROOT

Running setenv.sh without this change results in an error message:

```
ls: cannot access '/home/mythtv/android/android-sdk-linux/android-sdk-linux/build-tools': No such file or directory
Using discovered tools version 
```
and ANDROID_BUILD_TOOLS_REVISION is empty
