### PR TITLE
Make $HOME/Android the expected installation source of SDK and Studio

### DIFF
--- a/android/Readme.md
+++ b/android/Readme.md
@@ -14,13 +14,8 @@ NOTE: The build platform is linux
 
 2. Get Android Studio, SDK and NDK.
    * Get Android Studio from https://developer.android.com/studio/index.html
-     and install it. The default location is $HOME/Android. Install it in $HOME/android or else create a link from the default location:
-     
-```
-cd
-ln -s Android android
-```  
-   
+     and unpack it into $HOME/Android.
+
    * After Android Studio is installed, use it to install the Android SDK.
      * In Android Studio, choose Configure / SDK Manager.
      * Install the desired SDK versions.  Install SDK 29.
@@ -28,8 +23,7 @@ ln -s Android android
    * Set up links as follows, using the version of ndk that was installed.
 
 ```
-cd $HOME/android
-ln -s Sdk android-sdk-linux
+cd $HOME/Android
 ln -s Sdk/ndk/21.0.6113669 android-ndk
 ```
 
@@ -62,9 +56,8 @@ IGNOREDEFINES="-DIGNORE_SCHEMA_VER_MISMATCH -DIGNORE_PROTO_VER_MISMATCH"
    You should have a dir structure like this after you are done:
 
 ```
-ls -1 $HOME/android/
+ls -1 $HOME/Android/
 android-ndk -> Sdk/ndk/21.0.6113669
-android-sdk-linux -> Sdk
 android-studio
 Sdk
 ```
@@ -84,7 +77,7 @@ Sdk
 4. Fetch and build all the libraries.
    The script downloads source to build and builds it.
    In workdir/packaging/android, run this. Set "arm" or "arm64" for the mode. If you set the sdk version and ARM64 variable in buildrc you need not set them here.
-   
+
 ```
     make SDK=21 MODE=arm64 libs
 ```

--- a/android/android-utilities/setenv.sh
+++ b/android/android-utilities/setenv.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-ANDROID_ROOT=$HOME/android
+ANDROID_ROOT=$HOME/Android
 ANDROID_ROOT=`readlink -f "$ANDROID_ROOT"`
-export ANDROID_SDK=$ANDROID_ROOT/android-sdk-linux
+export ANDROID_SDK=$ANDROID_ROOT/Sdk
 export ANDROID_NDK=$ANDROID_ROOT/android-ndk
 export ANDROID_SDK_ROOT=$ANDROID_SDK
 export ANDROID_NDK_ROOT=$ANDROID_NDK
@@ -13,7 +13,7 @@ else
 	export ANDROID_BUILD_TOOLS_REVISION=29.0.2
 	echo "Using hardcoded tools version $ANDROID_BUILD_TOOLS_REVISION"
 fi
-export JAVA_HOME=${HOME}/android/android-studio/jre
+export JAVA_HOME=${ANDROID_ROOT}/android-studio/jre
 export JDK_PATH=${JAVA_HOME}/bin
 
 export ANDROID_KEYSTORE=$ANDROID_ROOT/sample-release.keystore

--- a/android/docker/docker_init.sh
+++ b/android/docker/docker_init.sh
@@ -55,8 +55,8 @@ NDKVER=`ls -1 ${INSTDIR}/ndk`
 SDKVER=`ls -1 ${INSTDIR}/platforms/ | sed 's/android-//'`
 BUILDTOOLSVER=`ls -1 ${INSTDIR}/build-tools`
 
-su "${USERNAME}" -c "mkdir -p ~/Android/android-studio && cd ~/Android && ln -s ${INSTDIR}/ Sdk && ln -s ${INSTDIR}/ndk/$NDKVER android-ndk"
-su "${USERNAME}" -c "ln -s $(dirname $(dirname $(readlink -f $(which javac)))) ~/Android/android-studio/jre"
+su "${USERNAME}" -c "mkdir -p ${HOME}/Android/android-studio && cd ${HOME}/Android && ln -s ${INSTDIR}/ Sdk && ln -s ${INSTDIR}/ndk/$NDKVER android-ndk"
+su "${USERNAME}" -c "ln -s $(dirname $(dirname $(readlink -f $(which javac)))) ${HOME}/Android/android-studio/jre"
 su "${USERNAME}" -c "git config --global user.email \"none@none.com\""
 su "${USERNAME}" -c "git config --global user.name \"No-one\""
 

--- a/android/docker/docker_init.sh
+++ b/android/docker/docker_init.sh
@@ -55,8 +55,8 @@ NDKVER=`ls -1 ${INSTDIR}/ndk`
 SDKVER=`ls -1 ${INSTDIR}/platforms/ | sed 's/android-//'`
 BUILDTOOLSVER=`ls -1 ${INSTDIR}/build-tools`
 
-su "${USERNAME}" -c "mkdir -p ~/android/android-studio && cd ~/android && ln -s ${INSTDIR}/ android-sdk-linux && ln -s ${INSTDIR}/ndk/$NDKVER android-ndk"
-su "${USERNAME}" -c "ln -s $(dirname $(dirname $(readlink -f $(which javac)))) ~/android/android-studio/jre"
+su "${USERNAME}" -c "mkdir -p ~/Android/android-studio && cd ~/Android && ln -s ${INSTDIR}/ Sdk && ln -s ${INSTDIR}/ndk/$NDKVER android-ndk"
+su "${USERNAME}" -c "ln -s $(dirname $(dirname $(readlink -f $(which javac)))) ~/Android/android-studio/jre"
 su "${USERNAME}" -c "git config --global user.email \"none@none.com\""
 su "${USERNAME}" -c "git config --global user.name \"No-one\""
 

--- a/android/installapk.sh
+++ b/android/installapk.sh
@@ -4,5 +4,5 @@ if [ -z "$1" ]; then
 	echo "Needs apk for parameter"
 fi
 
-#~/android/android-sdk-linux/platform-tools/adb install -r "$1"
+#~/Android/Sdk/platform-tools/adb install -r "$1"
 adb install -r "$1"

--- a/android/installapk.sh
+++ b/android/installapk.sh
@@ -4,5 +4,5 @@ if [ -z "$1" ]; then
 	echo "Needs apk for parameter"
 fi
 
-#~/Android/Sdk/platform-tools/adb install -r "$1"
+#${HOME}/Android/Sdk/platform-tools/adb install -r "$1"
 adb install -r "$1"

--- a/android/pushapk.sh
+++ b/android/pushapk.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-~/android/android-sdk-linux/platform-tools/adb push mythfrontend.apk /sdcard/Download/
+~/Android/Sdk/platform-tools/adb push mythfrontend.apk /sdcard/Download/

--- a/android/pushapk.sh
+++ b/android/pushapk.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-~/Android/Sdk/platform-tools/adb push mythfrontend.apk /sdcard/Download/
+${HOME}/Android/Sdk/platform-tools/adb push mythfrontend.apk /sdcard/Download/

--- a/android/startgdbserver.sh
+++ b/android/startgdbserver.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+ADB=~/Android/Sdk/platform-tools/adb
+
 if [ -n "$1" ]; then
-MPID=`~/android/android-sdk-linux/platform-tools/adb shell ps | grep mythfrontend | cut -c11-16`
+MPID=`${ADB} shell ps | grep mythfrontend | cut -c11-16`
 echo "MPID is $MPID"
-~/android/android-sdk-linux/platform-tools/adb shell su -c /data/data/org.mythtv.mythfrontend/lib/gdbserver :3333 --attach $MPID
+${ADB} shell su -c /data/data/org.mythtv.mythfrontend/lib/gdbserver :3333 --attach $MPID
 else
-MPID=`~/android/android-sdk-linux/platform-tools/adb shell ps w | grep mythfrontend | cut -c-5`
-~/android/android-sdk-linux/platform-tools/adb shell /data/data/org.mythtv.mythfrontend/lib/gdbserver :3333 --attach $MPID
+MPID=`${ADB} shell ps w | grep mythfrontend | cut -c-5`
+${ADB} shell /data/data/org.mythtv.mythfrontend/lib/gdbserver :3333 --attach $MPID
 fi
-#~/android/android-sdk-linux/platform-tools/adb shell /mnt/asec/org.mythtv.mythfrontend-1/lib/gdbserver :3333 --attach $MPID
+#${ADB} shell /mnt/asec/org.mythtv.mythfrontend-1/lib/gdbserver :3333 --attach $MPID
 

--- a/android/startgdbserver.sh
+++ b/android/startgdbserver.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ADB=~/Android/Sdk/platform-tools/adb
+ADB=${HOME}/Android/Sdk/platform-tools/adb
 
 if [ -n "$1" ]; then
 MPID=`${ADB} shell ps | grep mythfrontend | cut -c11-16`


### PR DESCRIPTION
This removes the requirement to make additional symlinks.