### PR TITLE
Prevent frontend from resurecting when the database is inaccessible

### DIFF
--- a/deb/debian/mythfrontend.sh
+++ b/deb/debian/mythfrontend.sh
@@ -35,7 +35,7 @@ if [ "$1" = "--service" ]; then
         else
             until $environ /usr/bin/mythfrontend.real --syslog local7 ${MYTHFRONTEND_OPTS}
                   RET=$?
-                  [ "$RET" = "0" -o "$RET" = "1" -o "$RET" = "254" ]
+                  [ "$RET" = "0" -o "$RET" = "1" -o "$RET" = "130" -o "$RET" = "254" ]
             do
                   notify-send -i info 'Restarting Frontend' "The front-end crashed unexpectedly (exit code $RET) and is restarting. Please wait..."
             done


### PR DESCRIPTION
I am using MythTV version 31 installed on Xubunutu 21.04 or 20.04 via the mythbuntu ppa.

When I launch the frontend without the backend running, it displays the loading bar, but when I try to exit, either before or after it times out, it thinks the frontend has crashed, so it relaunches. This obviously creates an inescapable loop, which is annoying.

Killing mythfrontend via xfce4-taskmanager does break the loop, but oddly mythfrontend.real doesn't show up in xfce4-taskmanager while gnome-system-monitor shows both.

Adding exit code 130 to the list in the script breaks the loop.  Exit code 130 is GENERIC_EXIT_NO_MYTHCONTEXT (https://github.com/MythTV/mythtv/blob/master/mythtv/libs/libmythbase/exitcodes.h ), which is a result of exiting the GUI startup screen (see mythcontext.cpp MythContextPrivate::FindDatabase() which returns false, causing MythContextPrivate::Init() to return false and thus MythContext::Init() to also return false, finally causing mythfontend to return 130 (https://github.com/MythTV/mythtv/blob/4eaa9cdbad0552d61f71a48019cbc6f9b1a14209/mythtv/programs/mythfrontend/main.cpp#L1896 )

GENERIC_EXIT_SOCKET_ERROR 135, may also need to be ignored based on its use in mythcontext.cpp.

Perhaps, abandoning the auto-restart entirely is a better option.

Alternatively, mythtv.desktop could be modified to call mythfrontend without the --service parameter.