### PR TITLE
Ignore .clazy file when building from source

### DIFF
--- a/deb/debian/source/options
+++ b/deb/debian/source/options
@@ -1,1 +1,1 @@
-extend-diff-ignore=.github|.dockerignore|.clang-tidy
+extend-diff-ignore=.github|.dockerignore|.clang-tidy|.clazy


### PR DESCRIPTION
Building using ./build-debs.sh master fails on mythtv master due
to the file .clazy which is classified as local change to the sources.
Note file .clazy does not exist in previous version e.g. fixes/31.

Fixes #100