### PR TITLE
Update OSX build script and codesiging

### DIFF
--- a/OSX/build/macports_ansible/codesignAndPackage.zsh
+++ b/OSX/build/macports_ansible/codesignAndPackage.zsh
@@ -21,7 +21,10 @@ For example, you can modify your user's ~/.zprofile to include:
   export APP_BNDL_ID="org.mythtv.mythfrontend"
 
 To notarize the application, your app password must be in your keychain as
-MYTHFRONTEND_APP_PWD. To do this, run the following command:
+MYTHFRONTEND_APP_PWD.
+To do this with Xcode 13 or newer, run the follwoing command:
+  xcrun notarytool store-credentials "MYTHFRONTEND_APP_PWD" --apple-id "YOUR_APPLE_ID" --team-id="YOUR_TEAM_ID" --password "YOUR_APP_PWD"
+To do this with older versions of Xcode, run the following command:
   security add-generic-password -a "YOUR_APPLE_ID" -w "YOUR_APP_PWD" -s "MYTHFRONTEND_APP_PWD"
 EOF
 
@@ -51,39 +54,39 @@ checkNotarization(){
   APPLE_ID=$2
   # loop until the notarization process finishes
   # loop for about 20 minutes, then exit
-  WAITIME=20
-  LOOPMAX=$(expr 1200 / $WAITIME)
+  WAITTIME=20
+  LOOPMAX=$(expr 1200 / $WAITTIME)
   # loop for ~20 minutes
   # Add initial sleep to prevent failing before the notarization task is accepted
   sleep $WAITTIME
   for ((i=1;i<=$LOOPMAX;i++));
   do
     # get notarization status
-    noteOutput=$(xcrun altool --notarization-info $APP_UUID -u $APPLE_ID -p "@keychain:MYTHFRONTEND_APP_PWD")
+    notaOutput=$(xcrun altool --notarization-info $APP_UUID -u $APPLE_ID -p "@keychain:MYTHFRONTEND_APP_PWD")
     # extract out the status line
-    STATUS=$(echo $noteOutput| gsed 1d | gsed 's/^.*Status: *//')
+    STATUS=$(echo $notaOutput| gsed 1d | gsed 's/^.*Status: *//')
     case $STATUS in
       # notarization still in progrss (can take 15 or so minutes)
       *progress*)
-        echo >&2 "      Waiting an additional $WAITIME seconds"
-        sleep $WAITIME
+        echo >&2 "      Waiting an additional $WAITTIME seconds"
+        sleep $WAITTIME
         ;;
       # status reflects success
       *sucess*)
-        echo >&2 $noteOutput
+        echo >&2 $notaOutput
         echo >&2 "      Notaization Accepted"
         retval=true
         break
         ;;
       # status reflects approval
       *Approved*)
-        echo >&2 $noteOutput
+        echo >&2 $notaOutput
         echo >&2 "      Notaization Accepted"
         retval=true
         break
         ;;
       *)
-        echo >&2 $noteOutput
+        echo >&2 $notaOutput
         echo >&2 "      Notarization Failed or Timedout, exiting"
         retval=false
         break
@@ -113,6 +116,7 @@ APP_EXE_DIR=$APP/Contents/MacOS
 APP_PLUGINS_DIR=$APP_FMWK_DIR/PlugIns/
 ARCH=$(/usr/bin/arch)
 OS_VERS=$(/usr/bin/sw_vers -productVersion)
+XCODE_VERS=$(/usr/bin/xcodebuild -version|grep "Xcode"|gsed 's/^.*Xcode *//'|grep -o '^[^.]\+')
 VERS=$(/usr/libexec/PlistBuddy -c 'print ":CFBundleShortVersionString"' $APP/Contents/Info.plist)
 FULLVERS=$($APP_EXE_DIR/mythfrontend --version|grep "MythTV Version"|gsed 's/^.*Version : *//')
 # trim -dirty in case we've patched the repo / fixed the Xcode 12.5 VERSION bug
@@ -132,14 +136,16 @@ if [ -z $APP_BNDL_ID ]; then
   # check if the user exported a custom bumdle ID, if not use the default
   APP_BNDL_ID=$APP_DFLT_BNDL_ID
 fi
-# to notarize the application, your app password must be in your keychain
-APPLE_ID=$(security find-generic-password -s "MYTHFRONTEND_APP_PWD" |grep acct|gsed 's/^.*<blob>=*//')
-if [ -z $APPLE_ID ]; then
-  echo "To notarize the application, your app password must be in your keychain as MYTHFRONTEND_APP_PWD"
-  echo "You can get an App password (with valid Apple ID) here: https://appleid.apple.com/account/manage"
-  echo "To do this, run the following command:"
-  echo '     security add-generic-password -a "YOUR_APPLE_ID" -w "YOUR_APP_PWD" -s "MYTHFRONTEND_APP_PWD"'
-  exit
+# to notarize the application with Xcode < 13, your app password must be in your keychain
+if [ $XCODE_VERS -lt 13 ]; then
+  APPLE_ID=$(security find-generic-password -s "MYTHFRONTEND_APP_PWD" |grep acct|gsed 's/^.*<blob>=*//')
+  if [ -z $APPLE_ID ]; then
+    echo "To notarize the application, your app password must be in your keychain as MYTHFRONTEND_APP_PWD"
+    echo "You can get an App password (with valid Apple ID) here: https://appleid.apple.com/account/manage"
+    echo "To do this, run the following command:"
+    echo '     security add-generic-password -a "YOUR_APPLE_ID" -w "YOUR_APP_PWD" -s "MYTHFRONTEND_APP_PWD"'
+    exit
+  fi
 fi
 
 echo "------------ Signing Application  ------------"
@@ -195,15 +201,33 @@ rm entitlement.plist
 
 echo "------------ Notarizing Application  ------------"
 echo "------------ Preparing App for Notarization  ------------"
+echo "      Creating file for submission"
 /usr/bin/ditto -c -k --keepParent $APP $APP.zip
 # notarize the App file
 # send the zipped dmg file to apple for notarization
-noteOutput=$(xcrun altool --notarize-app --primary-bundle-id $APP_BNDL_ID -u $APPLE_ID -p "@keychain:MYTHFRONTEND_APP_PWD" --file $APP.zip)
-# extract the upload specific UUID since we need it to track notarization status
-APP_UUID=$(echo $noteOutput| gsed 1d | gsed 's/^.*RequestUUID = *//')
-echo "App UUID is :$APP_UUID"
-echo "     Waiting on notarization to complete  ------------"
-NOTE_SUCCESS=$(checkNotarization $APP_UUID $APPLE_ID)
+echo "      Submitting file for notarization"
+if [ $XCODE_VERS -ge 13 ]; then
+  notaOutput=$(xcrun notarytool submit $APP.zip --keychain-profile "MYTHFRONTEND_APP_PWD" --wait)
+  echo $notaOutput
+  STATUS=$(echo $notaOutput | grep "status:"| gsed 1d | gsed 's/^.*status: *//')
+  echo $STATUS
+  case $STATUS in
+    *Accepted*)
+      echo "      Notaization Accepted"
+      NOTE_SUCCESS=true
+      ;;
+    *)
+      echo "      Notarization Failed or Timedout, exiting"
+      NOTE_SUCCESS=false
+  esac
+else
+  notaOutput=$(xcrun altool --notarize-app --primary-bundle-id $APP_BNDL_ID -u $APPLE_ID -p "@keychain:MYTHFRONTEND_APP_PWD" --file $APP.zip)
+  # extract the upload specific UUID since we need it to track notarization status
+  APP_UUID=$(echo $notaOutput| gsed 1d | gsed 's/^.*RequestUUID = *//')
+  echo "App UUID is :$APP_UUID"
+  echo "     Waiting on notarization to complete  ------------"
+  NOTE_SUCCESS=$(checkNotarization $APP_UUID $APPLE_ID)
+fi
 
 # clean up zip file
 rm $APP.zip
@@ -237,12 +261,28 @@ codesign --deep --force --verify --verbose --sign $CODESIGN_ID --options runtime
 # notarize the dmg file
 echo "------------ Notarizing DMG  ------------"
 # send the zipped dmg file to apple for notarization
-noteOutput=$(xcrun altool --notarize-app --primary-bundle-id $APP_BNDL_ID -u $APPLE_ID -p "@keychain:MYTHFRONTEND_APP_PWD" --file $DMG_FILE)
-# extract the upload specific UUID since we need it to track notarization status
-APP_UUID=$(echo $noteOutput| gsed 1d | gsed 's/^.*RequestUUID = *//')
-echo "DMG UUID is :$APP_UUID"
-echo "     Waiting on notarization to complete  ------------"
-NOTE_SUCCESS=$(checkNotarization $APP_UUID $APPLE_ID)
+echo "      Submitting dmg for notarization"
+if [ $XCODE_VERS -ge 13 ]; then
+  notaOutput=$(xcrun notarytool submit $DMG_FILE --keychain-profile "MYTHFRONTEND_APP_PWD" --wait)
+  echo $notaOutput
+  STATUS=$(echo $notaOutput | grep "status:"| gsed 1d | gsed 's/^.*status: *//')
+  case $STATUS in
+    *Accepted*)
+      echo "      Notaization Accepted"
+      NOTE_SUCCESS=true
+      ;;
+    *)
+      echo "      Notarization Failed or Timedout, exiting"
+      NOTE_SUCCESS=false
+  esac
+else
+  notaOutput=$(xcrun altool --notarize-app --primary-bundle-id $APP_BNDL_ID -u $APPLE_ID -p "@keychain:MYTHFRONTEND_APP_PWD" --file $DMG_FILE)
+  # extract the upload specific UUID since we need it to track notarization status
+  APP_UUID=$(echo $notaOutput| gsed 1d | gsed 's/^.*RequestUUID = *//')
+  echo "DMG UUID is :$APP_UUID"
+  echo "     Waiting on notarization to complete  ------------"
+  NOTE_SUCCESS=$(checkNotarization $APP_UUID $APPLE_ID)
+fi
 
 # if notarization if successful, staple the notarization onto the dmg file
 if $NOTE_SUCCESS; then

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -114,7 +114,7 @@ done
 # if we're building on master - get release number from the git tags
 # otherwise extract it from the MYTHTV_VERS
 case $MYTHTV_VERS in
-    master*|*32*)
+    master*|*33*)
        VERS=$(git ls-remote --tags  git://github.com/MythTV/mythtv.git|tail -n 1)
        VERS=${VERS##*/v}
        VERS=$(echo $VERS|tr -dc '0-9')

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -539,11 +539,11 @@ if [ -f setup.py ]; then
   rm setup.py
 fi
 
-echo "    Creating a temporary application from ttvdb.py"
+echo "    Creating a temporary application from ttvdb4.py"
 # in order to get python embedded in the application we're going to make a temporyary application
 # from one of the python scripts (ttvdb) which will copy in all the required libraries for
 # running and will make a standalone python executable not tied to the system
-# ttvdb seems to be more particular than tmdb3...
+# ttvdb4 seems to be more particular than tmdb3...
 
 # special handling for arm64 architecture until py2app is updated to fully support it
 if [ $(/usr/bin/arch)=="arm64" ]; then
@@ -551,7 +551,7 @@ if [ $(/usr/bin/arch)=="arm64" ]; then
 else
   PY2APP_ARCH=""
 fi
-$PY2APPLET_BIN $PY2APP_ARCH -p $PYTHON_RUNTIME_PKGS --site-packages --use-pythonpath --make-setup $INSTALL_DIR/share/mythtv/metadata/Television/ttvdb.py
+$PY2APPLET_BIN $PY2APP_ARCH -p $PYTHON_RUNTIME_PKGS --site-packages --use-pythonpath --make-setup $INSTALL_DIR/share/mythtv/metadata/Television/ttvdb4.py
 
 $PYTHON_BIN setup.py -q py2app 2>&1 > /dev/null
 # now we need to copy over the pythong app's pieces into the mythfrontend.app to get it working


### PR DESCRIPTION
Updates to the macOS build script to include:
- Rev to v33 post v32 branch cut
- Migrate py2app call from depricated ttvdb.py to ttvdb4.py
- Add the option to compile using QT6

Update the codesigning routine to use Xcode 13's new methods.