### PR TITLE
deb: stop using deprecated rsyslog '~' action

### DIFF
--- a/deb/debian/40-mythtv.conf
+++ b/deb/debian/40-mythtv.conf
@@ -5,37 +5,37 @@ $FileCreateMode 0644
 
 # Send all logging from MythTV applications to application-specific log files.
 if $msg startswith ' mythbackend' then /var/log/mythtv/mythbackend.log
-& ~
+& stop
 if $msg startswith ' mythfrontend' then /var/log/mythtv/mythfrontend.log
-& ~
+& stop
 if $msg startswith ' mythjobqueue' then /var/log/mythtv/mythjobqueue.log
-& ~
+& stop
 if $msg startswith ' mythmediaserver' then /var/log/mythtv/mythmediaserver.log
-& ~
+& stop
 if $msg startswith ' mythtv-setup' then /var/log/mythtv/mythtv-setup.log
-& ~
+& stop
 if $msg startswith ' mythfilldatabase' then /var/log/mythtv/mythfilldatabase.log
-& ~
+& stop
 if $msg startswith ' mythcommflag' then /var/log/mythtv/mythcommflag.log
-& ~
+& stop
 if $msg startswith ' mythpreviewgen' then /var/log/mythtv/mythpreviewgen.log
-& ~
+& stop
 if $msg startswith ' mythtranscode' then /var/log/mythtv/mythtranscode.log
-& ~
+& stop
 if $msg startswith ' mythmetadatalookup' then /var/log/mythtv/mythmetadatalookup.log
-& ~
+& stop
 if $msg startswith ' mythutil' then /var/log/mythtv/mythutil.log
-& ~
+& stop
 if $msg startswith ' mythwelcome' then /var/log/mythtv/mythwelcome.log
-& ~
+& stop
 if $msg startswith ' mythshutdown' then /var/log/mythtv/mythshutdown.log
-& ~
+& stop
 if $msg startswith ' mythlcdserver' then /var/log/mythtv/mythlcdserver.log
-& ~
+& stop
 if $msg startswith ' mythccextractor' then /var/log/mythtv/mythccextractor.log
-& ~
+& stop
 if $msg startswith ' mythavtest' then /var/log/mythtv/mythavtest.log
-& ~
+& stop
 
 # Set FileCreateMode back to default.  This should be the same value as specified
 # in the /etc/rsyslog.conf file.


### PR DESCRIPTION
On modern rsyslog (per git, >= 7.3 or so, in 2012), the use of the '~'
action leads to a slew of deprecation warnings when rsyslog starts:

rsyslogd: warning: ~ action is deprecated, consider using the 'stop' statement instead [v8.2102.0 try https://www.rsyslog.com/e/2307 ]

Switch to the 'stop' directive, which is functionally equivalent.