### PR TITLE
Allow building armhf deb-light packages on aarch64 hosts

### DIFF
--- a/deb-light/config.sh
+++ b/deb-light/config.sh
@@ -26,7 +26,7 @@ case $projname in
         if which $BUILD_PREPARE ; then
             $BUILD_PREPARE
         fi
-        if [[ `arch` == arm* ]] ; then
+        if [[ $arch == arm* ]] ; then
             config_opt="--enable-libmp3lame --disable-vdpau \
               --enable-opengl  \
               --disable-vaapi \


### PR DESCRIPTION
Hi

I use a 32-bit armhf docker container in a 64-bit aarch64 host to build mythtv-light for my Raspberry Pi.

The deb-light/config.sh script uses the host arch instead of the build arch at one point and so ffmpeg ends up getting configured wrongly and won't compile.

This pull request fixes it.