### PR TITLE
OSX: Master - update for arch tagging, python libs, and ansible playbook changes

### DIFF
--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -137,7 +137,7 @@ case $MYTHTV_VERS in
       EXTRA_MYTHPLUGIN_FLAG="--enable-fftw"
     ;;
 esac
-ARCH=$(/usr/bin/arch)
+ARCH=$(/usr/bin/uname -m)
 REPO_DIR=$REPO_PREFIX/mythtv-$VERS
 PYTHON_DOT_VERS="${PYTHON_VERS:0:1}.${PYTHON_VERS:1:4}"
 ANSIBLE_PLAYBOOK="ansible-playbook-$PYTHON_DOT_VERS"

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -44,6 +44,7 @@ BUILD_PLUGINS=false
 PYTHON_VERS="38"
 UPDATE_PORTS=false
 MYTHTV_VERS="master"
+MYTHTV_PYTHON_SCRIPT="ttvdb4"
 DATABASE_VERS=mariadb-10.2
 QT_VERS=qt5
 GENERATE_APP=true
@@ -612,24 +613,18 @@ if [ -f setup.py ]; then
   rm setup.py
 fi
 
-echo "    Creating a temporary application from ttvdb4.py"
+echo "    Creating a temporary application from $MYTHTV_PYTHON_SCRIPT"
 # in order to get python embedded in the application we're going to make a temporyary application
-# from one of the python scripts (ttvdb) which will copy in all the required libraries for
-# running and will make a standalone python executable not tied to the system
-# ttvdb4 seems to be more particular than tmdb3...
+# from one of the python scripts which will copy in all the required libraries for running
+# and will make a standalone python executable not tied to the system ttvdb4 seems to be more
+# particular than others (tmdb3)...
 
-# special handling for arm64 architecture until py2app is updated to fully support it
-if [ $(/usr/bin/arch)=="arm64" ]; then
-  PY2APP_ARCH="--arch=universal"
-else
-  PY2APP_ARCH=""
-fi
-$PY2APPLET_BIN $PY2APP_ARCH -p $PYTHON_RUNTIME_PKGS --site-packages --use-pythonpath --make-setup $INSTALL_DIR/share/mythtv/metadata/Television/ttvdb4.py
+$PY2APPLET_BIN -p $PYTHON_RUNTIME_PKGS --site-packages --use-pythonpath --make-setup $INSTALL_DIR/share/mythtv/metadata/Television/$MYTHTV_PYTHON_SCRIPT.py
 
 $PYTHON_BIN setup.py -q py2app 2>&1 > /dev/null
 # now we need to copy over the pythong app's pieces into the mythfrontend.app to get it working
 echo "    Copying in Python Framework libraries"
-cd $APP_DIR/PYTHON_APP/dist/ttvdb.app
+cd $APP_DIR/PYTHON_APP/dist/$MYTHTV_PYTHON_SCRIPT.app
 cp -RHnp Contents/Frameworks/* $APP_FMWK_DIR
 
 echo "    Copying in Python Binary"

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -255,13 +255,13 @@ case $QT_VERS in
        QT_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS
        QMAKE_CMD=$QT_PATH/bin/qmake
        QMAKE_SPECS=$QT_PATH/mkspecs/macx-clang
-       ANSIBLE_QT=$QT_VERS.yml
+       ANSIBLE_QT=mythtv.yml
     ;;
     *)
        QT_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS
        QMAKE_CMD=$QT_PATH/bin/qmake6
        QMAKE_SPECS=$QT_PATH/mkspecs/macx-clang
-       ANSIBLE_QT=$QT_VERS.yml
+       ANSIBLE_QT=mythtv.yml
        echo "!!!!! Building with Qt6 - disabling plugins !!!!!"
        BUILD_PLUGINS=false
     ;;
@@ -335,10 +335,10 @@ else
   export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
   case $QT_VERS in
       qt5)
-         $ANSIBLE_PLAYBOOK $ANSIBLE_QT --extra-vars "database_version=$DATABASE_VERS install_qtwebkit=$BUILD_PLUGINS" --ask-become-pass
+         $ANSIBLE_PLAYBOOK $ANSIBLE_QT --limit=localhost --extra-vars "database_version=$DATABASE_VERS install_qtwebkit=$BUILD_PLUGINS" --ask-become-pass
       ;;
       *)
-         $ANSIBLE_PLAYBOOK $ANSIBLE_QT --extra-vars "database_version=$DATABASE_VERS" --ask-become-pass
+         $ANSIBLE_PLAYBOOK $ANSIBLE_QT --limit=localhost --extra-vars "database_version=$DATABASE_VERS" --ask-become-pass
       ;;
   esac
 fi


### PR DESCRIPTION
Update the OSX compile script to:
- factor in a request to change the file architecture tagging
- update the python embeds to use ttdvb4
- fix the call to ansible in alignment with the mythtv ansible changes