### PR TITLE
OSX: Fixes/32 - Update compile script, code signing, and Readme

### DIFF
--- a/OSX/build/macports_ansible/README.md
+++ b/OSX/build/macports_ansible/README.md
@@ -3,16 +3,9 @@ This is directory contains the a packaging script for MythFrontend for MacOS and
 instructions. The use of this script is documented on the mythtv wiki here:
 https://www.mythtv.org/wiki/Building_MythFrontend_on_Mac_OS_X
 
-compileMythtvAnsible.zsh - A script that creates a MythFrontend.app and .dmg files.
-            The script downloads and installs any mythtv/mythplugins dependencies
-            as specified in the mythtv ansible repo via MacPorts.  It also clones the
-            appropriate ansible/mythtv/packaging git repos from github, compiles mythtv
-            and optionally mythplugins, bundles the necessary Support libraries and
-            files into the application, and finally generates a .dmg file for distribution.
-            This script uses osx-bundler.pl.
+* **compileMythtvAnsible.zsh** - A script that creates a MythFrontend.app and .dmg files. The script downloads and installs any mythtv/mythplugins dependencies as specified in the mythtv ansible repo via MacPorts.  It also clones the appropriate ansible/mythtv/packaging git repos from github, compiles mythtv and optionally mythplugins, bundles the necessary Support libraries and files into the application, and finally generates a .dmg file for distribution.
 
-codesignAndPackage.zsh - A script that code signs / notarizes the application, generates a 
-            dmg file, and code signs. / notarizes the dmg bundle.
+* **codesignAndPackage.zsh** - A script that code signs / notarizes the application, generates a dmg file, and code signs. / notarizes the dmg bundle.
 
 Before running the script, the user must have Xcode, Xcode Command Line Tools, and MacPorts
 working on their system.
@@ -40,12 +33,6 @@ The script automatically performs the following steps:
 1. Packages mythfrontend.app into a .dmg file
 
 # Why Build With MacPorts
-Currently, for MythTV builds, MacPorts has all of the necessary dependencies for compiling MythTV in it's repository. For this reason alone, it significantly simplifies getting all of the dependencies installed and working without the need to maintain countless download links and specific to macOS patches.
+For a fully functional MythTV with plugins, only MacPorts has all of the necessary dependencies for compiling MythTV in it's repository. For this reason alone, it significantly simplifies getting all of the dependencies installed and working without the need to maintain countless download links and specific to macOS patches.
 
-In the past I tried to build MythTV using both manual downloads and Homebrew. The manual install process was cumbersome and filled with too many macOS related patches that it was nearly impossible to keep under control.
-
-This lead me to use a macOS package manager. First I tried Homebew. Unfortunately, Homebrew's default QT install was missing Webkit (requiring a customer QT compile and install) and had mixed compatibility with some of the python mysql pieces.
-
-After much sunk time spent trying to get MythTV to compile on Homebrew, I switched over to MacPorts and got the dependencies installed in very short order. Seriously - they just worked.  
-
-If anyone is interested in trying the Homebrew route please do so. If you are successful - please make suggestions on how to update the compile script and ansible. The best way to do this is to use the mythtv [users mailing list](http://lists.mythtv.org/mailman/listinfo/mythtv-users) or [forums](https://forum.mythtv.org/).
+Mythtv does successfully build under Homebrew, but with limited capability as key libraries such as qtwebkit are not available wihout manual installation. If anyone is interested in trying the Homebrew route please do so. If you are successful - please make suggestions on how to update the compile script and ansible.

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -645,15 +645,13 @@ $PY2APPLET_BIN -p $PYTHON_RUNTIME_PKGS --site-packages --use-pythonpath --make-s
 $PYTHON_BIN setup.py -q py2app 2>&1 > /dev/null
 # now we need to copy over the pythong app's pieces into the mythfrontend.app to get it working
 echo "    Copying in Python Framework libraries"
-cd $APP_DIR/PYTHON_APP/dist/$MYTHTV_PYTHON_SCRIPT.app
-cp -RHnp Contents/Frameworks/* $APP_FMWK_DIR
-
+mv -n $APP_DIR/PYTHON_APP/dist/$MYTHTV_PYTHON_SCRIPT.app/Contents/Frameworks/* $APP_FMWK_DIR
 echo "    Copying in Python Binary"
-cp -p Contents/MacOS/python $APP_EXE_DIR
+mv $APP_DIR/PYTHON_APP/dist/$MYTHTV_PYTHON_SCRIPT.app/Contents/MacOS/python $APP_EXE_DIR
 echo "    Copying in Python Resources"
-cp -RHnp Contents/Resources/* $APP_RSRC_DIR
-cd $APP_DIR
+mv -n $APP_DIR/PYTHON_APP/dist/$MYTHTV_PYTHON_SCRIPT.app/Contents/Resources/* $APP_RSRC_DIR
 # clean up temp application
+cd $APP_DIR
 rm -Rf PYTHON_APP
 
 echo "------------ Replace application perl/python paths to relative paths inside the application   ------------"
@@ -701,7 +699,7 @@ echo "------------ Searching Applicaition for missing libraries ------------"
 # Do one last sweep for missing dylibs in the Framework Directory
 for dylib in $APP_FMWK_DIR/*.dylib; do
   pathDepList=$(/usr/bin/otool -L $dylib|grep -e $PKGMGR_INST_PATH/lib -e $INSTALL_DIR)
-  if [ ! -z "${pathDepList// }" ] ; then
+  if [ ! -z $pathDepList ] ; then
     installLibs $dylib
   fi
 done

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -42,11 +42,11 @@ EOF
 
 # setup default variables
 BUILD_PLUGINS=false
-PYTHON_VERS="38"
+PYTHON_VERS="310"
 UPDATE_PORTS=false
 MYTHTV_VERS="fixes/32"
 MYTHTV_PYTHON_SCRIPT="ttvdb4"
-DATABASE_VERS=mariadb-10.2
+DATABASE_VERS=mysql8
 QT_VERS=qt5
 GENERATE_APP=true
 GENERATE_DMG=false
@@ -176,8 +176,8 @@ esac
 
 # Add some flags for the compiler to find the package manager locations
 export LDFLAGS="-L$PKGMGR_INST_PATH/libexec/$QT_VERS/lib -L$PKGMGR_INST_PATH/lib"
-export C_INCLUDE_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray
-export CPLUS_INCLUDE_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray
+export C_INCLUDE_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun
+export CPLUS_INCLUDE_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun
 export LIBRARY_PATH=$PKGMGR_INST_PATH/libexec/$QT_VERS/lib/:$PKGMGR_INST_PATH/lib
 
 # setup some paths to make the following commands easier to understand


### PR DESCRIPTION
- Update README
- Codesign: Update code sign script to automatically unlock the keychain. 
- Compile Script: Update python and database defaults to track macports.
- Compile Script: Minor py2app cleanup to make python deployment work on the githu… 
- Compile Script: Add ability to specify the compiler used