### PR TITLE
OSX: Fixes/33 - Correct branch tag and update python to 311

### DIFF
--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -15,7 +15,7 @@ Standard options:
   --help                                 Print this message
   --build-plugins=BUILD_PLUGINS          Build Mythtvplugins (false)
   --python-version=PYTHON_VERS           Desired Python 3 Version (311)
-  --version=MYTHTV_VERS                  Requested mythtv git repo (master)
+  --version=MYTHTV_VERS                  Requested mythtv git repo (fixes/33)
   --database-version=DATABASE_VERS       Requested version of mariadb/mysql to build agains (mysql8)
   --qt-version=qt5                       Select Qt version to build against (qt5)
   --repo-prefix=REPO_PREFIX              Directory base to install the working repository (~)
@@ -47,7 +47,7 @@ OS_MAJOR=$OS_MAJOR[1]
 BUILD_PLUGINS=false
 PYTHON_VERS="311"
 UPDATE_PORTS=false
-MYTHTV_VERS="master"
+MYTHTV_VERS="fixes/33"
 MYTHTV_PYTHON_SCRIPT="ttvdb4"
 QT_VERS=qt5
 GENERATE_APP=true

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -14,7 +14,7 @@ Options: [defaults in brackets after descriptions]
 Standard options:
   --help                                 Print this message
   --build-plugins=BUILD_PLUGINS          Build Mythtvplugins (false)
-  --python-version=PYTHON_VERS           Desired Python 3 Version (310)
+  --python-version=PYTHON_VERS           Desired Python 3 Version (311)
   --version=MYTHTV_VERS                  Requested mythtv git repo (master)
   --database-version=DATABASE_VERS       Requested version of mariadb/mysql to build agains (mysql8)
   --qt-version=qt5                       Select Qt version to build against (qt5)
@@ -45,7 +45,7 @@ OS_MAJOR=$OS_MAJOR[1]
 
 # setup default variables
 BUILD_PLUGINS=false
-PYTHON_VERS="310"
+PYTHON_VERS="311"
 UPDATE_PORTS=false
 MYTHTV_VERS="master"
 MYTHTV_PYTHON_SCRIPT="ttvdb4"

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -15,7 +15,7 @@ Standard options:
   --help                                 Print this message
   --build-plugins=BUILD_PLUGINS          Build Mythtvplugins (false)
   --python-version=PYTHON_VERS           Desired Python 3 Version (311)
-  --version=MYTHTV_VERS                  Requested mythtv git repo (fixes/33)
+  --version=MYTHTV_VERS                  Requested mythtv git repo (${1})
   --database-version=DATABASE_VERS       Requested version of mariadb/mysql to build agains (mysql8)
   --qt-version=qt5                       Select Qt version to build against (qt5)
   --repo-prefix=REPO_PREFIX              Directory base to install the working repository (~)
@@ -72,7 +72,7 @@ fi
 for i in "$@"; do
   case $i in
       -h|--help)
-        show_help
+        show_help ${MYTHTV_VERS}
         exit 0
       ;;
       --build-plugins=*)


### PR DESCRIPTION
- Update default python to 311
- Update branch tagging to fixes/33