### PR TITLE
Add default set of config options for arm64

### DIFF
--- a/deb-light/config.sh
+++ b/deb-light/config.sh
@@ -26,7 +26,13 @@ case $projname in
         if which $BUILD_PREPARE ; then
             $BUILD_PREPARE
         fi
-        if [[ $arch == arm* ]] ; then
+        if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ] ; then
+            config_opt="--enable-libmp3lame --disable-vdpau \
+              --enable-opengl  \
+              --disable-vaapi \
+              --cpu=cortex-a72 --arch=aarch64  \
+              $MYTHTV_CONFIG_OPT_EXTRA"
+        elif [[ $arch == arm* ]] ; then
             config_opt="--enable-libmp3lame --disable-vdpau \
               --enable-opengl  \
               --disable-vaapi \
@@ -58,7 +64,13 @@ case $projname in
         fi
         cd ../mythtv
         git clean -Xfd
-        if [[ $arch == arm* ]] ; then
+        if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ] ; then
+            config_opt="--enable-libmp3lame --disable-vdpau \
+              --enable-opengl  \
+              --disable-vaapi \
+              --cpu=cortex-a72 --arch=aarch64  \
+              $MYTHTV_CONFIG_OPT_EXTRA"
+        elif [[ $arch == arm* ]] ; then
             config_opt="--enable-libmp3lame --disable-vdpau \
               --enable-opengl  \
               --disable-vaapi \


### PR DESCRIPTION
Fixes incorrect detection of arm64 as a 32-bit platform.
Adds default set of config options for arm64.

Cortex-a72 was chosen as the default because this used by the Raspberry Pi 4

Most of the options are just copied over, if something needs to be changed, let me know.

Fixes: #149