### PR TITLE
deb-light: package.sh pass arguments on exec

### DIFF
--- a/deb-light/package.sh
+++ b/deb-light/package.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 scriptname=`readlink -e "$0"`
 scriptpath=`dirname "$scriptname"`
+scriptargs=("$@")
 set -e
 
 #options
@@ -87,7 +88,7 @@ case $projname in
             echo $installdir/$packagename already exists - incrementing SUBRELEASE number
             let SUBRELEASE=SUBRELEASE+1
             export SUBRELEASE
-            exec "$scriptname"
+            exec "$scriptname" "${scriptargs[@]}"
         fi
         rm -rf $installdir/$packagename $installdir/$packagename.deb
         cp -a "$sourcedir/" "$installdir/$packagename/"
@@ -170,7 +171,7 @@ FINISH
             echo $installdir/$packagename already exists - incrementing SUBRELEASE number
             let SUBRELEASE=SUBRELEASE+1
             export SUBRELEASE
-            exec "$scriptname"
+            exec "$scriptname" "${scriptargs[@]}"
         fi
         if [[ ! -d $installdir/$mythtvpackagename ]] ; then
             echo $installdir/$mythtvpackagename does not exist.


### PR DESCRIPTION
If the deb package already exists during packaging, then on `exec` the original arguments are lost, resulting in unexpected behavior.
Passing the arguments on `exec` keeps the behavior consistent.

I think it would be beneficial in `fixes/33` too. Is it going to be cherry-picked, or should I open a pr against `fixes/33`?