### PR TITLE
Fixes/33 - OSX: tidy and assorted fixes                                            

### DIFF
--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -280,7 +280,7 @@ rebaseLibs(){
     rpathDepList=$(echo $rpathDepList| gsed 's/(.*//')
     while read -r dep; do
         lib=${dep##*/}
-        if [ -n $lib ]; then
+        if [ -n "$lib" ]; then
             install_name_tool -change $dep $RUNPREFIX/lib/$lib $binFile
         fi
     done <<< "$rpathDepList"
@@ -367,17 +367,19 @@ else
   fi
   cd $REPO_DIR/ansible
   export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
-  ANSIBLE_FLAGS="--limit=localhost  --ask-become-pass"
+  ANSIBLE_FLAGS="--limit=localhost"
 
   case $QT_VERS in
       qt5)
-         ANSIBLE_EXTRA_FLAGS="--extra-vars 'ansible_python_interpreter=$PYTHON_PKMGR_BIN database_version=$DATABASE_VERS install_qtwebkit=$BUILD_PLUGINS'"
+         ANSIBLE_EXTRA_FLAGS="--extra-vars \"ansible_python_interpreter=$PYTHON_PKMGR_BIN database_version=$DATABASE_VERS install_qtwebkit=$BUILD_PLUGINS\""
       ;;
       *)
-         ANSIBLE_EXTRA_FLAGS="--extra-vars ansible_python_interpreter=$PYTHON_PKMGR_BIN database_version=$DATABASE_VERS" 
+         ANSIBLE_EXTRA_FLAGS="--extra-vars \"ansible_python_interpreter=$PYTHON_PKMGR_BIN database_version=$DATABASE_VERS\""
       ;;
   esac
-  $ANSIBLE_PB_EXE $ANSIBLE_QT $ANSIBLE_FLAGS 
+  ANSIBLE_FULL_CMD="$ANSIBLE_PB_EXE $ANSIBLE_FLAGS $ANSIBLE_EXTRA_FLAGS $ANSIBLE_QT"
+  # Need to use eval as zsh does not split multiple-word variables (https://zsh.sourceforge.io/FAQ/zshfaq03.html)
+  eval ${ANSIBLE_FULL_CMD}
 fi
 
 echo "------------ Source the Python Virtual Environment ------------"

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -392,7 +392,6 @@ else
     git clone https://github.com/MythTV/ansible.git
   fi
   cd $REPO_DIR/ansible
-  export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
   ANSIBLE_FLAGS="--limit=localhost"
 
   case $QT_VERS in

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -237,8 +237,8 @@ esac
 # Add some flags for the compiler to find the package manager locations
 export LDFLAGS="-L$QT_PATH/lib -L$QT_PATH/plugins -L$PKGMGR_INST_PATH/lib"
 export C_INCLUDE_PATH=$QT_PATH/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun:$PKGMGR_INST_PATH/include/glslang
-export CPLUS_INCLUDE_PATH=$PQT_PATH/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun:$PKGMGR_INST_PATH/include/glslang
-export LIBRARY_PATH=$PQT_PATH/lib:$PQT_PATH/plugins:$PKGMGR_INST_PATH/lib
+export CPLUS_INCLUDE_PATH=$QT_PATH/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun:$PKGMGR_INST_PATH/include/glslang
+export LIBRARY_PATH=$QT_PATH/lib:$QT_PATH/plugins:$PKGMGR_INST_PATH/lib
 
 # setup some paths to make the following commands easier to understand
 SRC_DIR=$REPO_DIR/mythtv/mythtv


### PR DESCRIPTION
 Clean up the compile script attempting to correct for fortmatting       
 issues.  Apply updates for latest qt6 build and ansible configuration.  
 Finally, fix internal links of dylibs for mythutil and                  
 mythmetadatalookup.                                                     
 - tidy up trailing whitespace                                           
 - update to consitstent variable nameing                                
 - update qt6 logic                                                      
 - update mythtv build flags for deprecated qtwebkit/qtscript            
 - fix dylib paths for mythutil, mythmetadatalookup  