### PR TITLE
MASTER - OSX: tidy and assorted fixes

### DIFF
--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -392,7 +392,6 @@ else
     git clone https://github.com/MythTV/ansible.git
   fi
   cd $REPO_DIR/ansible
-  export ANSIBLE_DISPLAY_SKIPPED_HOSTS=false
   ANSIBLE_FLAGS="--limit=localhost"
 
   case $QT_VERS in

--- a/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
+++ b/OSX/build/macports_ansible/compileMythfrontendAnsible.zsh
@@ -237,8 +237,8 @@ esac
 # Add some flags for the compiler to find the package manager locations
 export LDFLAGS="-L$QT_PATH/lib -L$QT_PATH/plugins -L$PKGMGR_INST_PATH/lib"
 export C_INCLUDE_PATH=$QT_PATH/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun:$PKGMGR_INST_PATH/include/glslang
-export CPLUS_INCLUDE_PATH=$PQT_PATH/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun:$PKGMGR_INST_PATH/include/glslang
-export LIBRARY_PATH=$PQT_PATH/lib:$PQT_PATH/plugins:$PKGMGR_INST_PATH/lib
+export CPLUS_INCLUDE_PATH=$QT_PATH/include/:$PKGMGR_INST_PATH/include:$PKGMGR_INST_PATH/include/libbluray:$PKGMGR_INST_PATH/include/libhdhomerun:$PKGMGR_INST_PATH/include/glslang
+export LIBRARY_PATH=$QT_PATH/lib:$QT_PATH/plugins:$PKGMGR_INST_PATH/lib
 
 # setup some paths to make the following commands easier to understand
 SRC_DIR=$REPO_DIR/mythtv/mythtv


### PR DESCRIPTION
Clean up the compile script attempting to correct for fortmatting issues.  Apply updates for latest qt6 build and ansible configuration. Finally, fix internal links of dylibs for mythutil and mythmetadatalookup.
- tidy up trailing whitespace
- update to consitstent variable nameing
- update qt6 logic
- update mythtv build flags for deprecated qtwebkit/qtscript
- fix dylib paths for mythutil, mythmetadatalookup