### PR TITLE
Ubuntu: Enable builds on MythTV master (v36-Pre)

### DIFF
--- a/deb/debian/changelog
+++ b/deb/debian/changelog
@@ -1,3 +1,9 @@
+mythtv (2:36.0~master) noble; urgency=medium
+
+  * Dummy entry to bump version to 36
+
+ -- Roland Ernst <rcrernst@gmail.com>  Thu, 13 Feb 2024 20:15:49 +0100
+
 mythtv (2:35.0~master) noble; urgency=medium
 
   * Switch desktop to use the Web App rather than mythtv-setup

--- a/deb/debian/changelog.in
+++ b/deb/debian/changelog.in
@@ -1,3 +1,9 @@
+mythtv (2:36.0~master) noble; urgency=medium
+
+  * Dummy entry to bump version to 36
+
+ -- Roland Ernst <rcrernst@gmail.com>  Thu, 13 Feb 2024 20:15:49 +0100
+
 mythtv (2:35.0~master) noble; urgency=medium
 
   * Switch desktop to use the Web App rather than mythtv-setup


### PR DESCRIPTION
MythTV changed git master to v36-Pre, see
http://lists.mythtv.org/pipermail/mythtv-dev/2025-February/079936.html

Refs #199