### PR TITLE
macOS: fix working directory issue plus cleanup

### DIFF
--- a/macOS/compileMythtvAnsible_cmake.zsh
+++ b/macOS/compileMythtvAnsible_cmake.zsh
@@ -9,7 +9,7 @@ Standard Options:
   --help                                  Print this help message
   --version=MYTHTV_VERS                   Requested mythtv git repo (${1})
                                             Example: master for the latest master
-                                                     fixes/34 for version 34
+                                                     fixes/35 for version 35
   --build-plugins=BUILD_PLUGINS           Build MythTV Plugins (false)
 Environmental Options:
   --database-version=DATABASE_VERS        Requested version of mariadb/mysql to build agains (${3})
@@ -348,7 +348,6 @@ else
     INSTALL_DIR=$PKGMGR_INST_PATH
   fi
 fi
-
 RUNPREFIX=$INSTALL_DIR
 echoC "    Installing Build Outputs to $INSTALL_DIR" BLUE
 
@@ -380,7 +379,12 @@ case $PKGMGR in
 esac
 
 ### Configure and Build Functions ##################################################################
+# check to see if the working directory exists, if not create it
+if [ ! -d $WORKING_DIR ]; then
+  mkdir -p $WORKING_DIR
+fi
 runAnsible(){
+  cd $WORKING_DIR
   if $SKIP_ANSIBLE; then
     echoC "    User requested skip of ansible package installation" ORANGE
     return 0
@@ -540,6 +544,7 @@ configureAndBuild(){
                     -B $CMAKE_BUILD_DIR                   \
                     -G Ninja                              \
                     -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR   \
+                    -DCMAKE_RUN_PREFIX=$RUNPREFIX         \
                     $EXTRA_CMAKE_FLAGS"
   eval "${CONFIG_CMD}"
   echoC "------------ Building MythTV ------------" GREEN


### PR DESCRIPTION
  - Fix issue where the WORKINGDIR was not created before running anible.
  - Update comments to reflect v35 as fixes branch
  - Clean up stray return

This should be cherry-picked onto v35/fixes.  Please let me know if that causes any issues and I can create a v35 specific PR.