### PR TITLE
Add fonts-freefont-ttf aka FreeSans.ttf for MHEG

### DIFF
--- a/deb/debian/control
+++ b/deb/debian/control
@@ -150,6 +150,7 @@ Depends:
  default-mysql-client | virtual-mysql-client | mysql-client-5.7 | mysql-client-5.6 | mariadb-client,
  fonts-dejavu,
  fonts-droid-fallback | fonts-droid | ttf-droid,
+ fonts-freefonts-ttf,
  fonts-liberation | ttf-liberation,
  fonts-texgyre | tex-gyre,
  fonts-tlwg-purisa,


### PR DESCRIPTION
Add the font needed for MHEG. This is hardcoded as FreeSans.ttf which is in package fonts-freefont-ttf.

Fixes #1069