### PR TITLE
Debian: Workaround for missing 'pwgen' utility

### DIFF
--- a/deb/debian/mythtv-common.config
+++ b/deb/debian/mythtv-common.config
@@ -26,6 +26,10 @@ db_go || true
 
 db_get mythtv/mysql_mythtv_password
 if [ -z "$RET" ]; then
-    mythtv_password="$(pwgen -s 8)"
+    if which pwgen; then
+        mythtv_password="$(pwgen -s 8)"
+    else
+        mythtv_password="$(LC_ALL=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)"
+    fi
     db_set mythtv/mysql_mythtv_password "$mythtv_password"
 fi

--- a/deb/debian/mythtv-common.postinst
+++ b/deb/debian/mythtv-common.postinst
@@ -30,7 +30,11 @@ case "$1" in
 
     db_get mythtv/mysql_mythtv_password
     if [ -z "$RET" ]; then
-        mythtv_password="$(pwgen -s 8)"
+        if which pwgen; then
+            mythtv_password="$(pwgen -s 8)"
+        else
+            mythtv_password="$(LC_ALL=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)"
+        fi
         db_set mythtv/mysql_mythtv_password "$mythtv_password"
         db_subst mythtv/display_password password "$mythtv_password"
         db_input high mythtv/display_password || true


### PR DESCRIPTION
Albeit 'pwgen' is marked as 'Pre-Depends' in the control file, it is missing during installation.
Use '/dev/urandom' to generate a password, instead.

Fixes: MythTV/packaging#206