### PR TITLE
Fix MySQL 8.4 failure: enable mysql_native_password before creating MythTV user

### DIFF
--- a/deb/debian/mythtv-database.postinst
+++ b/deb/debian/mythtv-database.postinst
@@ -46,6 +46,20 @@ update_database() {
         QUERY="GRANT ALL PRIVILEGES ON $database.* TO '$mythtv_username'@'%' IDENTIFIED BY '$mythtv_password'; \
             GRANT ALL ON $database.* TO '$mythtv_username'@'%';"
     else
+        # Ensure mysql_native_password plugin is enabled before creating MythTV DB user
+        MYSQL_NATIVE_CONF="/etc/mysql/mysql.conf.d/enable-native-password.cnf"
+        if [ ! -f "$MYSQL_NATIVE_CONF" ]; then
+            cat > "$MYSQL_NATIVE_CONF" <<EOF
+[mysqld]
+mysql_native_password=ON
+EOF
+            # Reload MySQL configuration
+            if systemctl is-active --quiet mysql; then
+                systemctl restart mysql
+            else
+                systemctl start mysql
+            fi
+        fi
         QUERY="CREATE USER IF NOT EXISTS '$mythtv_username'@'%' IDENTIFIED WITH mysql_native_password; \
             ALTER USER '$mythtv_username'@'%' IDENTIFIED BY '$mythtv_password'; \
             GRANT ALL ON $database.* TO '$mythtv_username'@'%';"


### PR DESCRIPTION
This change fixes Issue #222 (mysql_native_password plugin not loaded on newer MySQL versions).

MySQL 8.4 (used in Ubuntu 26.04 and newer) does not load the mysql_native_password
plugin by default. The mythtv-database.postinst script creates the MythTV user
using:

    IDENTIFIED WITH mysql_native_password

This fails with:
    Plugin 'mysql_native_password' is not loaded

This patch:
 - creates /etc/mysql/mysql.conf.d/enable-native-password.cnf
 - enables the mysql_native_password plugin
 - restarts MySQL only if needed
 - does not change the default authentication plugin
 - remains compatible with MariaDB logic already in the script