### PR TITLE
Debian: Remove mythtv-backend-config from installation

### DIFF
--- a/deb/debian/mythtv-backend.install
+++ b/deb/debian/mythtv-backend.install
@@ -7,7 +7,6 @@ usr/bin/mythjobqueue
 usr/bin/mythtv-setup.real
 usr/bin/mythpreviewgen
 usr/bin/mythexternrecorder
-usr/share/mythtv/backend-config
 usr/share/mythtv/externrecorder
 
 #Copied in from debian/


### PR DESCRIPTION
Recent changes on mythtv/master removed /usr/share/mythtv/backend-config
 as a consequence of https://github.com/MythTV/mythtv/commit/5616911433
 Remove it from debian installation as well.
This commit fixes build failures on Ubuntu PPA builds for master.